### PR TITLE
fix feed height and add loading skeleton

### DIFF
--- a/src/components/TwitterSkeleton.jsx
+++ b/src/components/TwitterSkeleton.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+function TwitterSkeleton(props) {
+  const count = props?.count || 1;
+  const arr = [];
+  for (let i = 0; i < count; i++) {
+    arr?.push(i);
+  }
+
+  const style =
+    !!props?.width || !!props?.height
+      ? {
+          width: props?.width,
+          height: props?.height,
+        }
+      : undefined;
+
+  return (
+    <div
+      className="flex flex-col p-8 border rounded-lg h-fit overflow-clip gap-y-4 animate-pulse bg-gray-50"
+      style={style}
+    >
+      {arr?.map(() => (
+        <div className="flex flex-col gap-y-5">
+          <div className="flex flex-wrap items-center w-full gap-4">
+            <div className="flex-none w-12 h-12 bg-gray-200 rounded-full" />
+            <div className="w-1/2 h-4 bg-gray-200 rounded-3xl" />
+          </div>
+
+          <div className="w-full h-4 bg-gray-200 rounded-3xl" />
+          <div className="w-full h-4 bg-gray-200 rounded-3xl" />
+          <div className="w-full h-4 bg-gray-200 rounded-3xl" />
+
+          <div className="w-full border-b" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default TwitterSkeleton;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Heading from "../components/Heading.jsx";
 import PostPreview from "../components/PostPreview.jsx";
 import EpisodePreview from "../components/EpisodePreview.jsx";
@@ -15,6 +15,7 @@ import { faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { Timeline } from "react-twitter-widgets";
 import { Link } from "gatsby";
 import NoResults from "../components/NoResults.jsx";
+import TwitterSkeleton from "../components/TwitterSkeleton.jsx";
 
 function Home({ data }) {
   const posts = data.allContentfulBlogPost.edges;
@@ -22,6 +23,10 @@ function Home({ data }) {
   const episodes = data.allSimplecastEpisode.edges;
   let episodePreviews = [];
   let noResults = false;
+
+  const [twitterLoaded, setTwitterLoaded] = useState(false);
+
+  console.log(twitterLoaded);
 
   if (posts.length === 1) {
     postPreviews = [<NoResults />];
@@ -53,41 +58,41 @@ function Home({ data }) {
         title={"The Eye Test"}
         subtitle={"Welcome to the official home of The Eye Test Podcast."}
       />
-      <div className="flex flex-col gap-y-20 md:gap-y-24 lg:px-2 mb-16 md:mb-24">
+      <div className="flex flex-col mb-16 gap-y-20 md:gap-y-24 lg:px-2 md:mb-24">
         <div className="flex flex-col md:gap-x-4 gap-y-16 justify-items-stretch">
           {/* Landing Feature */}
           <div className="rounded border-slate-400">
             <div className="flex flex-col gap-y-4">
               {/* Hero */}
-              <div className="w-full flex flex-col md:flex-row md:items-center gap-x-8">
+              <div className="flex flex-col w-full md:flex-row md:items-center gap-x-8">
                 {/* Graphic */}
-                <div className="w-full flex justify-center md:justify-end md:w-6/12">
+                <div className="flex justify-center w-full md:justify-end md:w-6/12">
                   <FontAwesomeIcon
                     icon={faMicrophoneLines}
                     className="text-[5rem] lg:text-[6rem] text-slate-500/90 animate-icon-enter"
                   />
                 </div>
                 {/* Text */}
-                <div className="flex justify-center md:justify-start w-full mx-auto py-8 text-transparent bg-gradient-to-br from-theme-primary/80 to-theme-secondary/80 bg-clip-text">
+                <div className="flex justify-center w-full py-8 mx-auto text-transparent md:justify-start bg-gradient-to-br from-theme-primary/80 to-theme-secondary/80 bg-clip-text">
                   <FontAwesomeIcon
                     icon={faQuoteLeft}
                     pull="left"
-                    className="text-xl sm:text-2xl lg:text-3xl text-theme-primary/80 pr-2 -mt-2"
+                    className="pr-2 -mt-2 text-xl sm:text-2xl lg:text-3xl text-theme-primary/80"
                   />
-                  <p className="text-lg sm:text-xl lg:text-2xl text-center">
+                  <p className="text-lg text-center sm:text-xl lg:text-2xl">
                     This is The Eye Test Podcast.
                     <br />I am your host, Brian Donovan.
                   </p>
                   <FontAwesomeIcon
                     icon={faQuoteRight}
                     pull="right"
-                    className="text-xl sm:text-2xl lg:text-3xl text-theme-secondary/80 pl-2 mb-2 self-end"
+                    className="self-end pl-2 mb-2 text-xl sm:text-2xl lg:text-3xl text-theme-secondary/80"
                   />
                 </div>
               </div>
               {/* Featured Content */}
-              <div className="w-full mx-auto flex flex-col self-center gap-y-4 lg:gap-y-8 mt-8 md:mt-16">
-                <div className="flex gap-x-8 justify-center">
+              <div className="flex flex-col self-center w-full mx-auto mt-8 gap-y-4 lg:gap-y-8 md:mt-16">
+                <div className="flex justify-center gap-x-8">
                   <span className="block w-4/12 border-b"></span>
                   <FontAwesomeIcon
                     icon={faHeadphonesSimple}
@@ -95,16 +100,18 @@ function Home({ data }) {
                   />
                   <span className="block w-4/12 border-b"></span>
                 </div>
-                <div className="border rounded p-4">
-                  <h3 className="text-center text-slate-700 text-lg mb-6 flex flex-col lg:flex-row justify-center items-center">
+                <div className="p-4 border rounded">
+                  <h3 className="flex flex-col items-center justify-center mb-6 text-lg text-center text-slate-700 lg:flex-row">
                     <span>Listen to Brian's feature on</span>
-                    <span className="italic text-slate-900 lg:ml-1">Talkin Mets with Mike Silva</span>
+                    <span className="italic text-slate-900 lg:ml-1">
+                      Talkin Mets with Mike Silva
+                    </span>
                   </h3>
                   <iframe
                     allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
                     frameborder="0"
                     height="190"
-                    className="w-full mx-auto max-w-lg overflow-hidden bg-transparent animate-slow-fade-in"
+                    className="w-full max-w-lg mx-auto overflow-hidden bg-transparent animate-slow-fade-in"
                     sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
                     src="https://embed.podcasts.apple.com/us/podcast/part-2-talkin-mets-postmortem-panel/id271866252?i=1000582814244"
                   ></iframe>
@@ -115,14 +122,14 @@ function Home({ data }) {
         </div>
         {/* Episode Feature */}
         <div className="w-full">
-          <h3 className="text-3xl text-center lg:text-left text-slate-600 font-optician mb-4 lg:mb-8">
+          <h3 className="mb-4 text-3xl text-center lg:text-left text-slate-600 font-optician lg:mb-8">
             Latest Episodes
           </h3>
           {/* Episodes Grid */}
-          <div className="w-full pt-4 grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-y-12 gap-x-8 mb-4">
+          <div className="grid w-full grid-cols-1 pt-4 mb-4 lg:grid-cols-2 xl:grid-cols-3 gap-y-12 gap-x-8">
             {episodePreviews.slice(0, 3)}
             {/* Link to Episodes Page */}
-            <div className="flex justify-center xl:col-start-2 items-center">
+            <div className="flex items-center justify-center xl:col-start-2">
               <Link
                 key={"more-episodes"}
                 to={"/episodes"}
@@ -130,7 +137,7 @@ function Home({ data }) {
                   "w-full md:w-48 text-lg text-theme-primary hover:text-slate-500 bg-slate-50 border border-slate-400 hover:border-slate-500 px-6 py-2 rounded transition"
                 }
               >
-                <div className="flex items-center gap-x-2 justify-center">
+                <div className="flex items-center justify-center gap-x-2">
                   <span>More episodes</span>
                   <FontAwesomeIcon icon={faAngleRight} className="" />
                 </div>
@@ -140,7 +147,7 @@ function Home({ data }) {
         </div>
         {/* Featured Blog Posts */}
         <div className="w-full">
-          <h3 className="text-3xl text-center lg:text-left text-slate-600 font-optician mb-4 lg:mb-8">
+          <h3 className="mb-4 text-3xl text-center lg:text-left text-slate-600 font-optician lg:mb-8">
             Recent Blog Posts
           </h3>
           {/* Posts Grid */}
@@ -167,7 +174,7 @@ function Home({ data }) {
                   "w-full md:w-48 text-lg text-theme-primary hover:text-slate-500 bg-slate-50 border border-slate-400 hover:border-slate-500 px-6 py-2 rounded transition"
                 }
               >
-                <div className="flex items-center gap-x-2 justify-center">
+                <div className="flex items-center justify-center gap-x-2">
                   <span>More posts</span>
                   <FontAwesomeIcon icon={faAngleRight} className="" />
                 </div>
@@ -176,7 +183,7 @@ function Home({ data }) {
           </div>
         </div>
         {/* Twitter Feed */}
-        <div className="flex gap-x-8 justify-center">
+        <div className="flex justify-center gap-x-8">
           <span className="block w-4/12 border-b"></span>
           <FontAwesomeIcon
             icon={faTwitter}
@@ -184,7 +191,7 @@ function Home({ data }) {
           />
           <span className="block w-4/12 border-b"></span>
         </div>
-        <div className="w-full max-w-xl mx-auto -mt-8">
+        <div className="w-full max-w-xl mx-auto -mt-8 max-h-[505px] overflow-auto rounded-xl">
           <Timeline
             dataSource={{
               sourceType: "profile",
@@ -192,8 +199,11 @@ function Home({ data }) {
             }}
             options={{
               tweetLimit: 3,
+              height: 500,
             }}
+            onLoad={() => setTwitterLoaded(true)}
           />
+          {!twitterLoaded && <TwitterSkeleton count={3} height="500px" />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Twitter unexpectedly stopped accepting tweet limit attribute. Setting fixed height on embed to contain feed. Still loads a million tweets and takes several seconds to load, but at least no longer impacts the page layout.
Because feed has a noticeable load time, adding a skeleton loader.